### PR TITLE
Remove index field

### DIFF
--- a/src/enrichment.py
+++ b/src/enrichment.py
@@ -37,14 +37,13 @@ class LogEnricher:
 
         log_group = logs['logGroup']
         aws_namespace = _get_aws_namespace(log_group)
-        metadata = {'index': 'main',
-                      'logGroup': log_group,
-                      'logStream': logs['logStream'],
-                      'source': aws_namespace,
-                      'sourcetype': "aws:" + aws_namespace,
-                      'logForwarder': context.function_name.lower() + ":" + context.function_version,
-                      'region': self._parse_log_collector_function_arn(context)[0],
-                      'awsAccountId': logs['owner']}
+        metadata = {'logGroup': log_group,
+                    'logStream': logs['logStream'],
+                    'source': aws_namespace,
+                    'sourcetype': "aws:" + aws_namespace,
+                    'logForwarder': context.function_name.lower() + ":" + context.function_version,
+                    'region': self._parse_log_collector_function_arn(context)[0],
+                    'awsAccountId': logs['owner']}
         namespace_metadata = self._enricher_factory(metadata['source'])(context, log_group)
         metadata.update(namespace_metadata)
         return metadata

--- a/src/function.py
+++ b/src/function.py
@@ -50,7 +50,6 @@ class LogCollector:
 
         def _get_fields():
             result = dict(metadata)
-            del result['index']
             del result['host']
             del result['source']
             del result['sourcetype']
@@ -60,7 +59,6 @@ class LogCollector:
         for item in logs["logEvents"]:
             timestamp_as_string = str(item['timestamp'])
             hec_item = {'event': item['message'],
-                        'index': metadata['index'],
                         'fields': fields,
                         'host': metadata['host'],
                         'source': metadata['source'],

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -36,7 +36,6 @@ class LogCollectingSuite(TestCase):
 
         expected_event = {
             "event": log_message,
-            "index": "main",
             "fields": {
                 "logGroup": log_group,
                 "logStream": log_stream,

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -45,7 +45,6 @@ class LogEnrichmentSuite(TestCase):
             "host": arn,
             "source": "lambda",
             "sourcetype": "aws:lambda",
-            "index": "main",
             **CUSTOM_TAGS
         }
         self.assertEqual(expected, actual)
@@ -74,7 +73,6 @@ class LogEnrichmentSuite(TestCase):
             "host": arn,
             "source": "lambda",
             "sourcetype": "aws:lambda",
-            "index": "main",
         }
         self.assertEqual(expected, actual)
 
@@ -101,7 +99,6 @@ class LogEnrichmentSuite(TestCase):
             "host": host,
             "source": "rds",
             "sourcetype": "aws:rds",
-            "index": "main",
         }
         self.assertEqual(expected, actual)
 
@@ -128,8 +125,6 @@ class LogEnrichmentSuite(TestCase):
             "host": host,
             "source": "rds",
             "sourcetype": "aws:rds",
-            "index": "main",
-
         }
         self.assertEqual(expected, actual)
 
@@ -156,8 +151,6 @@ class LogEnrichmentSuite(TestCase):
             "host": host,
             "source": "rds",
             "sourcetype": "aws:rds",
-            "index": "main",
-
         }
         self.assertEqual(expected, actual)
 
@@ -184,7 +177,6 @@ class LogEnrichmentSuite(TestCase):
             "host": eks_cluster_name,
             "source": "eks",
             "sourcetype": "aws:eks",
-            "index": "main",
         }
 
         self.assertEqual(expected, actual)
@@ -211,7 +203,6 @@ class LogEnrichmentSuite(TestCase):
             "host": arn,
             "source": "api-gateway",
             "sourcetype": "aws:api-gateway",
-            "index": "main",
             **CUSTOM_TAGS,
         }
 


### PR DESCRIPTION
Based on discussion with log ingest team, we should not to send "index"