### PR TITLE
Publish metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ Code and deployment scripts for AWS lambda forwarding AWS logs to o11y log inges
 ## Quick link to the template.
 
 The quick link format is:
-`https://<region>.console.aws.amazon.com/cloudformation/home?region=<region>#/stacks/create/review?templateURL=https://<templateUrl>/packaged.yaml&param_IntegrationId=<integrationId>&param_SplunkAPIKey=<accessKey>&param_SplunkLogIngestUrl=<ingestUrl>`
+`https://<region>.console.aws.amazon.com/cloudformation/home?region=<region>#/stacks/create/review?templateURL=https://<templateUrl>/packaged.yaml&param_IntegrationId=<integrationId>&param_SplunkAPIKey=<accessKey>&param_SplunkLogIngestUrl=<logIngestUrl>&param_SplunkMetricIngestUrl=<metricIngestUrl>`
 

--- a/src/function.py
+++ b/src/function.py
@@ -4,13 +4,16 @@ import json
 import logging
 import os
 from io import BytesIO, BufferedReader
-from logger import log
+
 from client import BatchClient
 from enrichment import LogEnricher
+from logger import log
+from metric import SfxMetrics, size_of_json
 
-SPLUNK_URL = os.getenv("SPLUNK_URL", default="<unknown-url>")
+SPLUNK_LOG_URL = os.getenv("SPLUNK_LOG_URL", default="<unknown-url>")
+SPLUNK_METRIC_URL = os.getenv("SPLUNK_METRIC_URL", default="<unknown-url>")
 SPLUNK_API_KEY = os.getenv("SPLUNK_API_KEY", default="<unknown-token>")
-MAX_REQUEST_SIZE_IN_BYTES = int(os.getenv("MAX_REQUEST_SIZE_IN_BYTES", default=1024 * 800))
+MAX_REQUEST_SIZE_IN_BYTES = int(os.getenv("MAX_REQUEST_SIZE_IN_BYTES", default=2 * 1024 * 1024))
 COMPRESSION_LEVEL = int(os.getenv("COMPRESSION_LEVEL", default=6))
 TAGS_CACHE_TTL_SECONDS = int(os.getenv("TAGS_CACHE_TTL_SECONDS", default=15 * 60))
 
@@ -20,30 +23,40 @@ class LogCollector:
         self._log_enricher = LogEnricher.create(TAGS_CACHE_TTL_SECONDS)
 
     def forward_log(self, log_event, context):
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(f"Received Event:{json.dumps(log_event)}")
-            log.debug(f"Received context:{self._dump_object(context)}")
+        with SfxMetrics(SPLUNK_METRIC_URL, SPLUNK_API_KEY) as sfx_metrics:
+            try:
+                if log.isEnabledFor(logging.DEBUG):
+                    log.debug(f"Received Event:{json.dumps(log_event)}")
+                    log.debug(f"Received context:{self._dump_object(context)}")
+                aws_logs_base64 = log_event["awslogs"]["data"]
+                aws_logs_compressed = base64.b64decode(aws_logs_base64)
+                aws_logs = self._read_logs(aws_logs_compressed)
+                metadata = self._log_enricher.get_matadata(aws_logs, context, sfx_metrics)
+                sfx_metrics.namespace(metadata['source'])
+                self._send_input_metrics(sfx_metrics, aws_logs_base64, aws_logs_compressed, aws_logs)
 
-        logs = self._read_logs(log_event)
-        metadata = self._log_enricher.get_matadata(logs, context)
-        hec_logs = list(self._convert_to_hec(logs, metadata))
-        self._send_logs(hec_logs)
+                hec_logs = list(self._convert_to_hec(aws_logs, metadata))
+                self._send_logs(hec_logs, sfx_metrics)
+            except Exception as ex:
+                log.error(f"Exception occurred: {ex}")
+                sfx_metrics.inc_counter('sf.org.awsLogCollector.num.errors')
+                raise ex
+            finally:
+                sfx_metrics.inc_counter('sf.org.awsLogCollector.num.invocations')
 
     @staticmethod
-    def _read_logs(log_event):
+    def _read_logs(aws_logs):
         with gzip.GzipFile(
-                fileobj=BytesIO(base64.b64decode(log_event["awslogs"]["data"]))
+                fileobj=BytesIO(aws_logs)
         ) as decompress_stream:
             data = b"".join(BufferedReader(decompress_stream))
         return json.loads(data)
 
     @staticmethod
-    def _send_logs(logs):
-        with BatchClient.create(SPLUNK_URL, SPLUNK_API_KEY, MAX_REQUEST_SIZE_IN_BYTES, COMPRESSION_LEVEL) as client:
-            try:
-                client.send(logs)
-            except Exception:
-                log.exception(f"Exception while sending logs {logs}")
+    def _send_logs(logs, sfx_metrics):
+        with BatchClient.create(SPLUNK_LOG_URL, SPLUNK_API_KEY, MAX_REQUEST_SIZE_IN_BYTES, COMPRESSION_LEVEL,
+                                sfx_metrics) as client:
+            client.send(logs)
 
     @staticmethod
     def _convert_to_hec(logs, metadata):
@@ -67,6 +80,14 @@ class LogCollector:
                         }
 
             yield json.dumps(hec_item)
+
+    @staticmethod
+    def _send_input_metrics(sfx_metrics, aws_logs_base64, aws_logs_compressed, logs):
+        sfx_metrics.counters(
+                ('sf.org.awsLogCollector.num.inputBase64Bytes', len(aws_logs_base64)),
+                ('sf.org.awsLogCollector.num.inputCompressedBytes', len(aws_logs_compressed)),
+                ('sf.org.awsLogCollector.num.inputUncompressedBytes', size_of_json(logs))
+        )
 
     @staticmethod
     def _dump_object(context):

--- a/src/metric.py
+++ b/src/metric.py
@@ -1,0 +1,45 @@
+import json
+import time
+import signalfx
+
+
+def size_of_str(string):
+    return len(bytes(string, "utf-8"))
+
+
+def size_of_json(obj):
+    return size_of_str(json.dumps(obj))
+
+
+def _current_time():
+    return int(round(time.time() * 1000))
+
+
+class SfxMetrics(object):
+
+    def __init__(self, splunk_url, splunk_api_key):
+        self._sfx_metrics = signalfx.SignalFx(ingest_endpoint=splunk_url).ingest(splunk_api_key)
+        self._namespace = "unknown"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, ex_type, ex_value, traceback):
+        self._sfx_metrics.stop()
+
+    def inc_counter(self, metric_name):
+        self.counters((metric_name, 1))
+
+    def counters(self, *metric_name_values):
+        counters = list(map(lambda metric_name_value: self.counter(metric_name_value[0], metric_name_value[1]),
+                            metric_name_values))
+        self._sfx_metrics.send(counters=counters)
+
+    def namespace(self, namespace):
+        self._namespace = namespace
+
+    def counter(self, metric_name, metric_value):
+        return {'metric': metric_name,
+                'value': metric_value,
+                'dimensions': {'namespace': self._namespace},
+                'timestamp': _current_time()}

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,3 @@
 aws-lambda-context==1.1.0
 requests==2.24.0
+signalfx==1.1.13

--- a/template.yaml
+++ b/template.yaml
@@ -7,6 +7,8 @@ Parameters:
     Type: String
   SplunkLogIngestUrl:
     Type: String
+  SplunkMetricIngestUrl:
+    Type: String
   IntegrationId:
     Type: String
 
@@ -23,7 +25,8 @@ Resources:
       Environment:
         Variables:
           SPLUNK_API_KEY: !Ref SplunkAPIKey
-          SPLUNK_URL: !Ref SplunkLogIngestUrl
+          SPLUNK_LOG_URL: !Ref SplunkLogIngestUrl
+          SPLUNK_METRIC_URL: !Ref SplunkMetricIngestUrl
       Policies:
         - AWSLambdaBasicExecutionRole
         - Statement:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2,8 +2,9 @@ import base64
 import gzip
 import json
 import unittest
+import signalfx
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from client import BatchClient
 from enrichment import TagsCache
@@ -12,6 +13,7 @@ from test_enrichment import lambda_context, read_from_file, CUSTOM_TAGS, FORWARD
     FORWARDER_FUNCTION_NAME, FORWARDER_FUNCTION_VERSION, AWS_REGION, AWS_ACCOUNT_ID
 
 
+@patch.object(signalfx.SignalFx, "ingest")
 @patch.object(BatchClient, "send")
 @patch.object(TagsCache, "get")
 class LogCollectingSuite(TestCase):
@@ -19,7 +21,7 @@ class LogCollectingSuite(TestCase):
     def setUp(self) -> None:
         self.log_forwarder = LogCollector()
 
-    def test_lambda(self, tags_cache_get_mock, send_method_mock):
+    def test_lambda(self, tags_cache_get_mock, send_method_mock, _):
         # GIVEN
         tags_cache_get_mock.return_value = CUSTOM_TAGS
         event, cw_event = self._read_aws_log_event_from_file('sample_lambda_log.json')

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -19,6 +19,7 @@ class LogEnrichmentSuite(TestCase):
 
     def setUp(self) -> None:
         self.tag_cache_mock = Mock()
+        self.sfx_metrics = Mock()
         self.log_enricher = LogEnricher(self.tag_cache_mock)
 
     def test_lambda_enrichment(self):
@@ -27,7 +28,7 @@ class LogEnrichmentSuite(TestCase):
         event = read_from_file('sample_lambda_log.json')
 
         # WHEN
-        actual = self.log_enricher.get_matadata(event, lambda_context())
+        actual = self.log_enricher.get_matadata(event, lambda_context(), self.sfx_metrics)
 
         # THEN
         log_group = event['logGroup']
@@ -55,7 +56,7 @@ class LogEnrichmentSuite(TestCase):
         event = read_from_file('sample_lambda_log.json')
 
         # WHEN
-        actual = self.log_enricher.get_matadata(event, lambda_context())
+        actual = self.log_enricher.get_matadata(event, lambda_context(), self.sfx_metrics)
 
         # THEN
         log_group = event['logGroup']
@@ -82,7 +83,7 @@ class LogEnrichmentSuite(TestCase):
         event = read_from_file('sample_rds_postgres_log.json')
 
         # WHEN
-        actual = self.log_enricher.get_matadata(event, lambda_context())
+        actual = self.log_enricher.get_matadata(event, lambda_context(), self.sfx_metrics)
 
         # THEN
         log_group = event['logGroup']
@@ -108,7 +109,7 @@ class LogEnrichmentSuite(TestCase):
         event = read_from_file('sample_rds_mysql_log.json')
 
         # WHEN
-        actual = self.log_enricher.get_matadata(event, lambda_context())
+        actual = self.log_enricher.get_matadata(event, lambda_context(), self.sfx_metrics)
 
         # THEN
         log_group = event['logGroup']
@@ -134,7 +135,7 @@ class LogEnrichmentSuite(TestCase):
         event = read_from_file('sample_rds_aurora_cluster_log.json')
 
         # WHEN
-        actual = self.log_enricher.get_matadata(event, lambda_context())
+        actual = self.log_enricher.get_matadata(event, lambda_context(), self.sfx_metrics)
 
         # THEN
         log_group = event['logGroup']
@@ -160,7 +161,7 @@ class LogEnrichmentSuite(TestCase):
         event = read_from_file('sample_eks_log.json')
 
         # WHEN
-        actual = self.log_enricher.get_matadata(event, lambda_context())
+        actual = self.log_enricher.get_matadata(event, lambda_context(), self.sfx_metrics)
 
         # THEN
         log_group = event['logGroup']
@@ -187,7 +188,7 @@ class LogEnrichmentSuite(TestCase):
         event = read_from_file('sample_api_gateway_log.json')
 
         # WHEN
-        actual = self.log_enricher.get_matadata(event, lambda_context())
+        actual = self.log_enricher.get_matadata(event, lambda_context(), self.sfx_metrics)
 
         # THEN
         arn = "arn:aws:apigateway:us-east-1::/restapis/kgiqlx3nok/stages/prod"


### PR DESCRIPTION
- remove batch client support (it is not needed because the max size of async lambda request is 256kB, log ingest limit is 2MB)
- add metrics
- increase timeout to 20seconds