### PR TITLE
Adding filters in later stages back. Apparently it you cannot remove …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,16 @@ workflows:
           context: aws-rnd-lambda-extension-user
           requires:
             - zip-and-save-release
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/
       - publish-github-release:
           requires:
             - upload-release
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/


### PR DESCRIPTION
…these filters if they contain tags, but you can omit them on later stages if they contain branches only